### PR TITLE
exit the postback response immediately

### DIFF
--- a/app/code/community/Sign2pay/Payment/controllers/PaymentController.php
+++ b/app/code/community/Sign2pay/Payment/controllers/PaymentController.php
@@ -47,6 +47,7 @@ class Sign2pay_Payment_PaymentController extends Mage_Core_Controller_Front_Acti
         try {
             $data = $this->getRequest()->getPost();
             Mage::getModel('sign2pay/processor')->processRequest($data);
+            exit;
         } catch (Exception $e) {
             Mage::logException($e);
             $this->getResponse()->setHttpResponseCode(500);


### PR DESCRIPTION
We never want to append anything in this response. This change ensures
that the response body is sent to the client. We've had reports that
some servers would respond with a double JSON body.
